### PR TITLE
Fix non-matching default limit

### DIFF
--- a/client/jsonapi/templates/supplier/standard.php
+++ b/client/jsonapi/templates/supplier/standard.php
@@ -18,7 +18,7 @@ $config = $this->config( 'client/jsonapi/url/config', [] );
 
 $total = $this->get( 'total', 0 );
 $offset = max( $this->param( 'page/offset', 0 ), 0 );
-$limit = max( $this->param( 'page/limit', 100 ), 1 );
+$limit = max( $this->param( 'page/limit', 25 ), 1 );
 
 $first = ( $offset > 0 ? 0 : null );
 $prev = ( $offset - $limit >= 0 ? $offset - $limit : null );


### PR DESCRIPTION
The default for page/limit was different in [`client/jsonapi/src/Client/JsonApi/Supplier/Standard.php`](https://github.com/aimeos/ai-client-jsonapi/blob/master/client/jsonapi/src/Client/JsonApi/Supplier/Standard.php#L147) compared to here (25 there vs 100 here).
This was causing the **next** link to be incorrectly excluded from the response when there was over 25 suppliers.

The next calculation with a total of **28** would here be:
```
$next = ( $offset + $limit < $total ? $offset + $limit : null ); // 0  + 100 < 28 => $next = null
```
Even though the there would only be 25 entries in `$items`